### PR TITLE
Misc improvements

### DIFF
--- a/src/bank00.asm
+++ b/src/bank00.asm
@@ -636,13 +636,13 @@ hideSpritesBehindWindow_trampoline:
 showSpritesBehindWindow_trampoline:
     jp_to_bank 02, showSpritesBehindWindow             ;; 00:0435 $f5 $3e $05 $c3 $06 $1f
 
-call_00_043b:
+spriteShuffleDoFlash_trampoline:
     ld   A, [wBossFirstObjectID]                       ;; 00:043b $fa $e8 $d3
     cp   A, $ff                                        ;; 00:043e $fe $ff
     ret  NZ                                            ;; 00:0440 $c0
     jp_to_bank 02, call_02_44fa                        ;; 00:0441 $f5 $3e $02 $c3 $06 $1f
 
-call_00_0447:
+spriteShuffleShowHidden_trampoline:
     jp_to_bank 02, call_02_44c4                        ;; 00:0447 $f5 $3e $03 $c3 $06 $1f
 
 setSpriteScrollSpeed:
@@ -678,7 +678,7 @@ getBackgroundDrawAddress:
     ld   C, A                                          ;; 00:0473 $4f
     ld   B, $00                                        ;; 00:0474 $06 $00
     add  HL, BC                                        ;; 00:0476 $09
-    ld   BC, $9800                                     ;; 00:0477 $01 $00 $98
+    ld   BC, $9800 ;@=ptr _SCRN0                       ;; 00:0477 $01 $00 $98
     add  HL, BC                                        ;; 00:047a $09
     ret                                                ;; 00:047b $c9
 
@@ -962,6 +962,7 @@ getObjectNearestTilePosition:
     ret                                                ;; 00:0610 $c9
 
 ; Update the object at index C to the position at D,E
+; Object orientation/flags set to A & 7f
 ; Also does something with B
 updateObjectPosition:
     ld   L, A                                          ;; 00:0611 $6f
@@ -1067,11 +1068,10 @@ getObjectPositionAndCollisionInfo:
     dec  E                                             ;; 00:0693 $1d
     ret                                                ;; 00:0694 $c9
 
-; Main entry point for hit detection? Or possibly it's an "updateObjects" function?
 ; A = ?
 ; B = ?
 ; C = Object ID for the changed/checked object
-call_00_0695:
+processPhysicsForObject:
     ld   D, A                                          ;; 00:0695 $57
     ld   E, B                                          ;; 00:0696 $58
     ld   A, C                                          ;; 00:0697 $79
@@ -5274,7 +5274,7 @@ InitPreIntEnable:
     call CopyHL_to_DE_size_BC                          ;; 00:2027 $cd $40 $2b
     call copyInitialVRAMTiles                          ;; 00:202a $cd $40 $21
     ld   A, $7f                                        ;; 00:202d $3e $7f
-    ld   HL, $9800                                     ;; 00:202f $21 $00 $98
+    ld   HL, $9800 ;@=ptr _SCRN0                       ;; 00:202f $21 $00 $98
     ld   BC, $800                                      ;; 00:2032 $01 $00 $08
     call FillHL_with_A_times_BC                        ;; 00:2035 $cd $54 $2b
     ld   A, $00                                        ;; 00:2038 $3e $00
@@ -6791,58 +6791,47 @@ playSFX:
     ldh  [hSFX], A                                     ;; 00:297f $e0 $92
     ret                                                ;; 00:2981 $c9
 
-; 0 -> 3
-; 1 -> 0
-; 2 -> 1
-; 3 -> 0
-; 4 -> 2
-; 5 -> 0
-; 6 -> 1
-; 7 -> 0
-; ... etc
-; All in all it returns 50% 0, 25% 1, 12.5% 2, and 12.5% 3
-; Gets the lowest set bit number of the first three bits, with 0 treated as 8.
-call_00_2982:
+; 01->00, 02->01, 04->02, 08->03
+; Only works for the lowest set bit of bits 0 to 3.
+getBitNumber:
     bit  0, A                                          ;; 00:2982 $cb $47
     jr   NZ, .jr_00_2991                               ;; 00:2984 $20 $0b
     bit  1, A                                          ;; 00:2986 $cb $4f
     jr   NZ, .jr_00_2994                               ;; 00:2988 $20 $0a
     bit  2, A                                          ;; 00:298a $cb $57
     jr   NZ, .jr_00_2997                               ;; 00:298c $20 $09
+;.bit_3:
     ld   A, $03                                        ;; 00:298e $3e $03
     ret                                                ;; 00:2990 $c9
-.jr_00_2991:
+.bit_0:
     ld   A, $00                                        ;; 00:2991 $3e $00
     ret                                                ;; 00:2993 $c9
-.jr_00_2994:
+.bit_1:
     ld   A, $01                                        ;; 00:2994 $3e $01
     ret                                                ;; 00:2996 $c9
-.jr_00_2997:
+.bit_2:
     ld   A, $02                                        ;; 00:2997 $3e $02
     ret                                                ;; 00:2999 $c9
 
-; A & 3:
-; 0 -> 1
-; 1 -> 2
-; 2 -> 4
-; 3 -> 8
-; Probably considered the inverse of the above function
-getA_And3Power2:
+; 00->01, 01->02, 02->04, 03->08
+; Only works for bits 0 to 3.
+getBitValue:
     and  A, $03                                        ;; 00:299a $e6 $03
     jr   Z, .jr_00_29a9                                ;; 00:299c $28 $0b
     cp   A, $01                                        ;; 00:299e $fe $01
     jr   Z, .jr_00_29ac                                ;; 00:29a0 $28 $0a
     cp   A, $02                                        ;; 00:29a2 $fe $02
     jr   Z, .jr_00_29af                                ;; 00:29a4 $28 $09
+;.bit_3:
     ld   A, $08                                        ;; 00:29a6 $3e $08
     ret                                                ;; 00:29a8 $c9
-.jr_00_29a9:
+.bit_0:
     ld   A, $01                                        ;; 00:29a9 $3e $01
     ret                                                ;; 00:29ab $c9
-.jr_00_29ac:
+.bit_1:
     ld   A, $02                                        ;; 00:29ac $3e $02
     ret                                                ;; 00:29ae $c9
-.jr_00_29af:
+.bit_2:
     ld   A, $04                                        ;; 00:29af $3e $04
     ret                                                ;; 00:29b1 $c9
 
@@ -7877,7 +7866,7 @@ drawWindow_trampoline:
 windowMenuStartSpecial_trampoline:
     jp_to_bank 02, windowMenuStartSpecial              ;; 00:30b1 $f5 $3e $15 $c3 $06 $1f
 
-call_00_30b7:
+windowPrintMenuText_trampoline:
     jp_to_bank 02, call_02_5b68                        ;; 00:30b7 $f5 $3e $16 $c3 $06 $1f
 
 initStartingStatsAndTimers_trampoline:
@@ -7949,7 +7938,7 @@ drawWillBarCharge_trampoline:
 drawEmptyWillBar_trampoline:
     jp_to_bank 02, drawEmptyWillBar                    ;; 00:314d $f5 $3e $2f $c3 $06 $1f
 
-InitPostIntEnable_trampoline:
+titleScreenInit_trampoline:
     jp_to_bank 02, titleScreenInit                     ;; 00:3153 $f5 $3e $30 $c3 $06 $1f
 
 gameStateTitleScreen_trampoline:
@@ -9183,7 +9172,7 @@ tilePositionToWindowVRAMaddress:
     add  A, L                                          ;; 00:38d5 $85
     ld   E, A                                          ;; 00:38d6 $5f
     ld   D, H                                          ;; 00:38d7 $54
-    ld   HL, $9c00                                     ;; 00:38d8 $21 $00 $9c
+    ld   HL, $9c00 ;@=ptr _SCRN1                       ;; 00:38d8 $21 $00 $9c
     add  HL, DE                                        ;; 00:38db $19
     scf                                                ;; 00:38dc $37
     ret                                                ;; 00:38dd $c9
@@ -9701,7 +9690,7 @@ clearNamesAndScriptFlags:
     jr   NZ, clearNamesAndScriptFlags.loop_flags       ;; 00:3bc8 $20 $fc
     ret                                                ;; 00:3bca $c9
 
-call_00_3bcb:
+opCodeFFPrintTextOption:
     pop  HL                                            ;; 00:3bcb $e1
     call call_00_30b7                                  ;; 00:3bcc $cd $b7 $30
     ret                                                ;; 00:3bcf $c9

--- a/src/bank00.asm
+++ b/src/bank00.asm
@@ -6660,7 +6660,8 @@ checkForFollower:
     ld   A, $01                                        ;; 00:28d2 $3e $01
     ret                                                ;; 00:28d4 $c9
 
-call_00_28d5:
+; Used when you ASK your Chocobo/Chocobot/Chocoboat
+hideFollower:
     call checkForFollower                              ;; 00:28d5 $cd $c2 $28
     ret  NZ                                            ;; 00:28d8 $c0
     ld   A, $00                                        ;; 00:28d9 $3e $00
@@ -6681,7 +6682,8 @@ call_00_28d5:
     ld   [HL+], A                                      ;; 00:28ee $22
     ret                                                ;; 00:28ef $c9
 
-call_00_28f0:
+; Used when you dismount your Chocobo/Chocobot/Chocoboat
+showFollower:
     call checkForFollower                              ;; 00:28f0 $cd $c2 $28
     ret  NZ                                            ;; 00:28f3 $c0
     ld   A, $00                                        ;; 00:28f4 $3e $00
@@ -9690,7 +9692,7 @@ clearNamesAndScriptFlags:
     jr   NZ, clearNamesAndScriptFlags.loop_flags       ;; 00:3bc8 $20 $fc
     ret                                                ;; 00:3bca $c9
 
-opCodeFFPrintTextOption:
+opCodeFFPrintMenuText:
     pop  HL                                            ;; 00:3bcb $e1
     call call_00_30b7                                  ;; 00:3bcc $cd $b7 $30
     ret                                                ;; 00:3bcf $c9
@@ -9809,7 +9811,8 @@ runVirtualScriptOpCodeFF:
     ld   [wScriptCommand], A                           ;; 00:3c6f $ea $5a $d8
     ret                                                ;; 00:3c72 $c9
 
-call_00_3c73:
+; Trampoline handling does not preserve the value of F, so F is fixed after the call.
+saveRegisterState2_bank0:
     push AF                                            ;; 00:3c73 $f5
     push AF                                            ;; 00:3c74 $f5
     call saveRegisterState2_trampoline                 ;; 00:3c75 $cd $99 $30
@@ -9825,7 +9828,8 @@ call_00_3c73:
     pop  AF                                            ;; 00:3c85 $f1
     ret                                                ;; 00:3c86 $c9
 
-call_00_3c87:
+; Trampoline handling does not preserve the value of F, so F is fixed after the call.
+loadRegisterState2_bank0:
     call loadRegisterState2_trampoline                 ;; 00:3c87 $cd $81 $30
     push BC                                            ;; 00:3c8a $c5
     ld   A, [wRegisterSave2.A]                         ;; 00:3c8b $fa $b1 $d8

--- a/src/bank01.asm
+++ b/src/bank01.asm
@@ -2303,7 +2303,7 @@ call_01_4f7b:
     ld   HL, $00                                       ;; 01:5084 $21 $00 $00
     ret                                                ;; 01:5087 $c9
 
-call_01_5088:
+snapPositionToNearestTile8_1:
     and  A, $fc                                        ;; 01:5088 $e6 $fc
     bit  2, A                                          ;; 01:508a $cb $57
     ret  Z                                             ;; 01:508c $c8

--- a/src/bank01.asm
+++ b/src/bank01.asm
@@ -1268,7 +1268,7 @@ updatePlayerPostion:
     call updateObjectPosition                          ;; 01:4992 $cd $11 $06
     ret                                                ;; 01:4995 $c9
 
-call_01_4996:
+processPhysicsForPlayer:
     ld   B, $00                                        ;; 01:4996 $06 $00
     ld   C, $04                                        ;; 01:4998 $0e $04
     call call_00_0695                                  ;; 01:499a $cd $95 $06

--- a/src/bank02.asm
+++ b/src/bank02.asm
@@ -801,7 +801,8 @@ showSpritesBehindWindow:
     pop  BC                                            ;; 02:44af $c1
     ret                                                ;; 02:44b0 $c9
 
-call_02_44b1:
+; HL = OAM location of sprite's Y coordinate
+spriteShuffleShowSprite:
     push AF                                            ;; 02:44b1 $f5
     push DE                                            ;; 02:44b2 $d5
     push HL                                            ;; 02:44b3 $e5
@@ -817,7 +818,8 @@ call_02_44b1:
     pop  AF                                            ;; 02:44c2 $f1
     ret                                                ;; 02:44c3 $c9
 
-call_02_44c4:
+; Sprites hidden by the shuffling routine are moved to y=$ce so any sprites with that y value should be restored.
+spriteShuffleShowHidden:
     ld   HL, wOAMBuffer                                ;; 02:44c4 $21 $00 $c0
     ld   B, $28                                        ;; 02:44c7 $06 $28
     ld   A, $ce                                        ;; 02:44c9 $3e $ce
@@ -830,7 +832,7 @@ call_02_44c4:
     jr   NZ, call_02_44c4.loop                         ;; 02:44d4 $20 $f8
     ret                                                ;; 02:44d6 $c9
 
-call_02_44d7:
+spriteShuffleHideSprite:
     ld   A, [wC4A0]                                    ;; 02:44d7 $fa $a0 $c4
     cp   A, $ff                                        ;; 02:44da $fe $ff
     jr   NZ, .jr_02_44e2                               ;; 02:44dc $20 $04
@@ -854,7 +856,7 @@ call_02_44d7:
     pop  HL                                            ;; 02:44f8 $e1
     ret                                                ;; 02:44f9 $c9
 
-call_02_44fa:
+spriteShuffleDoFlash:
     ld   HL, wC480                                     ;; 02:44fa $21 $80 $c4
     ld   B, $14                                        ;; 02:44fd $06 $14
     ld   A, $00                                        ;; 02:44ff $3e $00
@@ -2349,11 +2351,12 @@ call_02_50b5:
     ld   [wMenuStateCurrentFunction], A                ;; 02:5153 $ea $53 $d8
     ret                                                ;; 02:5156 $c9
 
-clearStatusBar:
+; Used by Save/Load/Status windows to fullscreen the hardware Window
+showFullscreenWindow:
     ld   A, [wVideoWY]                                 ;; 02:5157 $fa $a9 $c0
     ld   [wVideoWYBackup], A                           ;; 02:515a $ea $84 $d8
     ld   B, $40                                        ;; 02:515d $06 $40
-    ld   HL, $9c00                                     ;; 02:515f $21 $00 $9c
+    ld   HL, $9c00 ;@=ptr _SCRN1                       ;; 02:515f $21 $00 $9c
 .loop:
     push BC                                            ;; 02:5162 $c5
     push HL                                            ;; 02:5163 $e5
@@ -2368,7 +2371,7 @@ clearStatusBar:
     ld   [wVideoWY], A                                 ;; 02:5170 $ea $a9 $c0
     ret                                                ;; 02:5173 $c9
 
-call_02_5174:
+vendorShowBuyMessage:
     ld   A, $0f                                        ;; 02:5174 $3e $0f
     ld   [wDialogType], A                              ;; 02:5176 $ea $4a $d8
     call drawWindow                                    ;; 02:5179 $cd $00 $67
@@ -3880,7 +3883,7 @@ call_02_5aaf:
     call drawText                                      ;; 02:5ac9 $cd $77 $37
     jp   jp_02_5922                                    ;; 02:5acc $c3 $22 $59
 
-call_02_5acf:
+windowStatusScreenPrintStatValue:
     ld   A, [wD846]                                    ;; 02:5acf $fa $46 $d8
     ld   C, A                                          ;; 02:5ad2 $4f
     ld   B, $00                                        ;; 02:5ad3 $06 $00
@@ -3980,7 +3983,8 @@ jp_02_5b2c:
     ld   B, A                                          ;; 02:5b64 $47
     call runVirtualScriptOpCodeFF                      ;; 02:5b65 $cd $69 $3c
 
-call_02_5b68:
+; This isn't the only way of printing text to a window, but it is commonly used for plain text.
+windowPrintMenuText:
     push HL                                            ;; 02:5b68 $e5
     call loadRegisterState2                            ;; 02:5b69 $cd $a7 $6d
     push BC                                            ;; 02:5b6c $c5
@@ -6874,7 +6878,8 @@ call_02_75f4:
     call drawText                                      ;; 02:7629 $cd $77 $37
     ret                                                ;; 02:762c $c9
 
-call_02_762d:
+; Formatted for display in the Status window, with a blank in the middle
+initStatusHPMPCurrentAndMax:
     ld   HL, wStatusHPMPCurrentAndMax                  ;; 02:762d $21 $93 $d7
     ld   A, [wHPHigh]                                  ;; 02:7630 $fa $b3 $d7
     ld   D, A                                          ;; 02:7633 $57
@@ -6908,7 +6913,8 @@ call_02_762d:
     ld   [HL], D                                       ;; 02:765a $72
     ret                                                ;; 02:765b $c9
 
-call_02_765c:
+; Called five times to print HP, Max HP, Nothing, MP, Max MP
+statusWindowPrintHPMPCurOrMax:
     push AF                                            ;; 02:765c $f5
     push HL                                            ;; 02:765d $e5
     push BC                                            ;; 02:765e $c5
@@ -7042,7 +7048,8 @@ call_02_7693:
     xor  A, A                                          ;; 02:7733 $af
     ret                                                ;; 02:7734 $c9
 
-call_02_7735:
+; Used to save game
+getGraphicsAndMusicState:
     ld   HL, wDialogX                                  ;; 02:7735 $21 $a7 $d4
     push HL                                            ;; 02:7738 $e5
     call getMapNumber                                  ;; 02:7739 $cd $0a $22
@@ -7500,7 +7507,7 @@ playWindowErrorSound:
     pop  AF                                            ;; 02:7a25 $f1
     ret                                                ;; 02:7a26 $c9
 
-call_02_7a27:
+hideFullscreenWindow:
     call showStatusBar                                 ;; 02:7a27 $cd $3a $7a
     ld   A, [wVideoWYBackup]                           ;; 02:7a2a $fa $84 $d8
     ld   [wVideoWY], A                                 ;; 02:7a2d $ea $a9 $c0
@@ -7509,7 +7516,8 @@ call_02_7a27:
     call showSpritesBehindWindow_trampoline            ;; 02:7a36 $cd $35 $04
     ret                                                ;; 02:7a39 $c9
 
-showStatusBar:
+; If there's a window open (like the SELECT window) it would be inconvenient to have its sprites hidden.
+disableStatusBarEffect:
     push DE                                            ;; 02:7a3a $d5
     ld   D, $8e                                        ;; 02:7a3b $16 $8e
     ld   E, $7e                                        ;; 02:7a3d $1e $7e
@@ -7517,7 +7525,7 @@ showStatusBar:
     pop  DE                                            ;; 02:7a42 $d1
     ret                                                ;; 02:7a43 $c9
 
-hideStatusBar:
+enableStatusBarEffect:
     push DE                                            ;; 02:7a44 $d5
     ld   D, $7e                                        ;; 02:7a45 $16 $7e
     ld   E, $8e                                        ;; 02:7a47 $1e $8e
@@ -7526,7 +7534,9 @@ hideStatusBar:
     ret                                                ;; 02:7a4d $c9
 
 ; Used to hide/show the status bar
-lcdcEffectChangeLCY:
+; D = search (old) value
+; E = new value
+lcdcEffectChangeLYC:
     push HL                                            ;; 02:7a4e $e5
     push BC                                            ;; 02:7a4f $c5
     ld   HL, wLCDCEffectBuffer                         ;; 02:7a50 $21 $a0 $d3
@@ -7912,7 +7922,7 @@ titleScreenIntroScrollLoop:
     ret                                                ;; 02:7cba $c9
 .a_button:
     ld   B, $24                                        ;; 02:7cbb $06 $24
-    ld   DE, $9800                                     ;; 02:7cbd $11 $00 $98
+    ld   DE, $9800 ;@=ptr _SCRN0                       ;; 02:7cbd $11 $00 $98
     call clearVRAMArea                                 ;; 02:7cc0 $cd $6a $56
     ld   A, $03                                        ;; 02:7cc3 $3e $03
     ld   [wTitleScreenState], A                        ;; 02:7cc5 $ea $86 $d8

--- a/src/bank03.asm
+++ b/src/bank03.asm
@@ -1977,7 +1977,7 @@ updateObjectPosition_3:
     call updateObjectPosition                          ;; 03:4af1 $cd $11 $06
     ret                                                ;; 03:4af4 $c9
 
-call_03_4af5:
+processPhysicsForObject_3:
     call call_00_0695                                  ;; 03:4af5 $cd $95 $06
     ret                                                ;; 03:4af8 $c9
 

--- a/src/bank04.asm
+++ b/src/bank04.asm
@@ -1250,7 +1250,7 @@ processHitBoss:
     ld   A, $40                                        ;; 04:4732 $3e $40
     ret                                                ;; 04:4734 $c9
 
-call_04_4735:
+processPhysicsForObject_4:
     call call_00_0695                                  ;; 04:4735 $cd $95 $06
     ret                                                ;; 04:4738 $c9
 

--- a/src/bank09.asm
+++ b/src/bank09.asm
@@ -17,7 +17,7 @@ SECTION "bank09", ROMX[$4000], BANK[$09]
     call_to_bank_target getProjectilePower             ;; 09:400e ??
     call_to_bank_target projectileCollisionHandling    ;; 09:4010 pP
 
-call_09_4012:
+processPhysicsForObject_9:
     call call_00_0695                                  ;; 09:4012 $cd $95 $06
     ret                                                ;; 09:4015 $c9
 

--- a/src/bank0B_titlegfx_bossgfx.asm
+++ b/src/bank0B_titlegfx_bossgfx.asm
@@ -11,6 +11,7 @@ SECTION "bank0b", ROMX[$4000], BANK[$0b]
 tilesetGfxTitle:
     INCBIN "title_end.bin"                             ;; 0b:4000
 ;@gfximg name=trashbin width=2 height=8
+trashbinGfx:
     INCBIN "trashbin.bin"                              ;; 0b:4c00
 
 ;@gfximg name=boss/vampire width=2 height=12

--- a/src/memory.asm
+++ b/src/memory.asm
@@ -423,10 +423,11 @@ wRoomScriptTableHigh:
 wRoomClearedStatus:
     ds 128                                             ;; c400
 
-wC480:
+; Sprite shuffling to flash instead of permanently hide is implemented by moving them offscreen in rotation if there are two many on a line.
+wSpriteShuffleScratch:
     ds 32                                              ;; c480
 
-wC4A0:
+wSpriteShuffleHiddenSpriteAddressLow:
     ds 1                                               ;; c4a0
 
 ; "It takes all the running you can do, to keep in the same place.
@@ -436,7 +437,8 @@ wSpriteScrollSpeed:
     ds 1                                               ;; c4a1
 
 ; Sprites are hidden by moving them offscreen vertically.
-hiddenSpritesYPositions:
+; This is used to shuffle sprites so they flash instead of just disappearing when the line limit is exceeded.
+wSpriteShufflehiddenSpritesYPositions:
     ds 46                                              ;; c4a2
 
 wFlyingSwordSpecialOriginalLocationX:
@@ -1587,13 +1589,14 @@ hSoundEffectLoopCounterChannel1:
 hSoundEffectLoopCounterChannel4:
     ds 93                                              ;; ff9d
 
-hFFFA:
+; These next three are used as values for signed math. BadBoy understands this, yet still adds them here.
+hUnusedFFFA:
     ds 2                                               ;; fffa
 
-hFFFC:
+hUnusedFFFC:
     ds 1                                               ;; fffc
 
-hFFFD:
+hUnusedFFFD:
     ds 1                                               ;; fffd
 
 ; Used as the stack location at init for exactly one call, but also used as -2.


### PR DESCRIPTION
* Some corrections from the last changes.
* Label call_00_0695 as processPhysicsForObject, which also includes the final trampoline functions for bank 4 and 9.
* Labeling the sprite flashing code, which includes the final two unlabeled calls used by the main loop's functions.
* Some window related labeling.
* Other misc.