### PR TITLE
Fix for version 0.9.2 of rgbds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(ROM): $(patsubst src/%.asm,.obj/%.o,$(SRCS))
 
 .obj/%.o $(DEPDIR)/%.mk: src/%.asm $(patsubst gfx/%.png,.gfx/%.bin,$(GFXS))
 	@mkdir -p $(dir .obj/$* .dep/$*)
-	rgbasm --halt-without-nop --preserve-ld -Wall -Wextra --export-all -Isrc -I.gfx -M .dep/$*.mk -MP -MQ .obj/$*.o -MQ .dep/$*.mk -o .obj/$*.o $<
+	rgbasm -Wall -Wextra --export-all -Isrc -I.gfx -M .dep/$*.mk -MP -MQ .obj/$*.o -MQ .dep/$*.mk -o .obj/$*.o $<
 
 .gfx/%.bin: gfx/%.png
 	@mkdir -p $(dir .gfx/$*)


### PR DESCRIPTION
From what I can tell, these options have been made permanent and thereby removed from the command line argument list